### PR TITLE
Refactor student identifier from email to LRN for

### DIFF
--- a/src/pages/Teacher/TeacherSpecificClass/helpers/updateStudentsInClassApi.js
+++ b/src/pages/Teacher/TeacherSpecificClass/helpers/updateStudentsInClassApi.js
@@ -2,13 +2,13 @@ import { updateStudentsInClassEndpoint } from "@/config/teacherEndpoints";
 import getAuthHeaders from "@/utils/getAuthHeaders";
 import axios from "axios";
 
-const updateStudentsInClassApi = async (classId, studentEmails) => {
+const updateStudentsInClassApi = async (classId, studentLrns) => {
   try {
     const response = await axios.patch(
       updateStudentsInClassEndpoint,
       {
         classId,
-        studentEmails,
+        studentLrns,
       },
       getAuthHeaders(),
     );

--- a/src/pages/Teacher/TeacherSpecificClass/partials/StudentsTable.jsx
+++ b/src/pages/Teacher/TeacherSpecificClass/partials/StudentsTable.jsx
@@ -31,7 +31,7 @@ export default function StudentsTable() {
         if (classDetails && isEditing) {
           await fetchStudentsApi(setAllStudents);
           setSelectedStudents(
-            classDetails.students.map((student) => student.emailAddress),
+            classDetails.students.map((student) => student.lrn),
           );
         } else if (classDetails) {
           setAllStudents(classDetails.students);
@@ -118,8 +118,8 @@ export default function StudentsTable() {
                 <TableCell>
                   <input
                     type="checkbox"
-                    checked={selectedStudents.includes(student.emailAddress)}
-                    onChange={() => handleAddStudent(student.emailAddress)}
+                    checked={selectedStudents.includes(student.lrn)}
+                    onChange={() => handleAddStudent(student.lrn)}
                   />
                 </TableCell>
               )}


### PR DESCRIPTION
consistency and privacy

Update the student selection logic and API payload to use LRN instead of email. This provides consistency and enhances privacy.